### PR TITLE
Fix wrong package name if annotation processing is done with Eclipse …

### DIFF
--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -142,9 +142,7 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         String annotationBuilderPackageName = builderAnnotation.packageName();
         if (annotationBuilderPackageName.isEmpty()) {
             PackageElement targetClassPackage = elements.getPackageOf(targetClassType);
-            return targetClassPackage.isUnnamed()
-                    ? ""
-                    : targetClassPackage.toString();
+            return targetClassPackage.getQualifiedName().toString();
         } else {
             return annotationBuilderPackageName;
         }


### PR DESCRIPTION
…JDT compiler

While OpenJDK / Sun compiler prints out the fully qualified name for PackageElement objects, the Eclipse JDT compiler adds a 'package ' in front of it which leads to wrong path name when generating the builder files. To fix this, the qualified name is explicitly used.

Code of eclipse JDT toString() method:
<img width="982" alt="eclipse_jdt_adds_package_to_string" src="https://user-images.githubusercontent.com/1167681/210554031-16b4569c-0034-4e58-8c25-c7aab2a100fd.png">

Compared to OpenJDK:
<img width="262" alt="Open JDK to string" src="https://user-images.githubusercontent.com/1167681/210554594-88a4e145-f1eb-4223-aa1f-31eee3cc1593.png">

.isUnnamed() check is not necessary anymore, because getQualifiedName() returns an empty string in case of an empty package.