### PR TITLE
Add meta-annotation support

### DIFF
--- a/src/main/java/org/jilt/Builder.java
+++ b/src/main/java/org/jilt/Builder.java
@@ -225,7 +225,7 @@ import java.lang.annotation.Target;
  * @see #buildMethod
  * @see BuilderInterfaces
  */
-@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)
 public @interface Builder {
     /**

--- a/src/main/java/org/jilt/BuilderInterfaces.java
+++ b/src/main/java/org/jilt/BuilderInterfaces.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * @see Builder#style
  * @see BuilderStyle
  */
-@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)
 public @interface BuilderInterfaces {
     /**

--- a/src/main/java/org/jilt/JiltAnnotationProcessor.java
+++ b/src/main/java/org/jilt/JiltAnnotationProcessor.java
@@ -40,7 +40,7 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
         getAnnotatedElements(roundEnv).forEach((annotatedElement, builderAnnotations) -> {
             try {
                 builderGeneratorFactory.forElement(annotatedElement, builderAnnotations).generateBuilderClass();
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 error(annotatedElement, e.getMessage());
             }
         });

--- a/src/main/java/org/jilt/JiltAnnotationProcessor.java
+++ b/src/main/java/org/jilt/JiltAnnotationProcessor.java
@@ -1,9 +1,8 @@
 package org.jilt;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import org.jilt.internal.BuilderGeneratorFactory;
+import org.jilt.utils.Annotations;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -15,8 +14,10 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
-import org.jilt.internal.BuilderGeneratorFactory;
-import org.jilt.utils.Annotations;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class JiltAnnotationProcessor extends AbstractProcessor {
     private Messager messager;
@@ -25,7 +26,7 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
     private BuilderGeneratorFactory builderGeneratorFactory;
 
     @Override
-    public synchronized void init(final ProcessingEnvironment processingEnv) {
+    public synchronized void init(ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
 
         messager = processingEnv.getMessager();
@@ -35,11 +36,11 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
     }
 
     @Override
-    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         getAnnotatedElements(roundEnv).forEach((annotatedElement, builderAnnotations) -> {
             try {
                 builderGeneratorFactory.forElement(annotatedElement, builderAnnotations).generateBuilderClass();
-            } catch(final Exception e) {
+            } catch (final Exception e) {
                 error(annotatedElement, e.getMessage());
             }
         });
@@ -47,11 +48,11 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
         return true;
     }
 
-    private Map<Element, Annotations> getAnnotatedElements(final RoundEnvironment roundEnv) {
-        final Set<? extends Element> builderElements = roundEnv.getElementsAnnotatedWith(Builder.class);
-        final Map<Element, Annotations> annotatedElements = initMap(builderElements, null, null);
-        for(final Element builderElement : builderElements) {
-            if(builderElement.getKind() == ElementKind.ANNOTATION_TYPE) {
+    private Map<Element, Annotations> getAnnotatedElements(RoundEnvironment roundEnv) {
+        Set<? extends Element> builderElements = roundEnv.getElementsAnnotatedWith(Builder.class);
+        Map<Element, Annotations> annotatedElements = initMap(builderElements, null, null);
+        for (Element builderElement : builderElements) {
+            if (builderElement.getKind() == ElementKind.ANNOTATION_TYPE) {
                 annotatedElements.remove(builderElement);
                 annotatedElements.putAll(initMap(roundEnv.getElementsAnnotatedWith((TypeElement) builderElement),
                     builderElement.getAnnotation(Builder.class), builderElement.getAnnotation(BuilderInterfaces.class)));
@@ -61,16 +62,15 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
         return annotatedElements;
     }
 
-    private Map<Element, Annotations> initMap(final Set<? extends Element> builderElements, final Builder builderAnnotation,
-        final BuilderInterfaces builderInterfaces) {
-        final Map<Element, Annotations> map = new HashMap<>();
-        for(final Element element : builderElements) {
+    private Map<Element, Annotations> initMap(Set<? extends Element> builderElements, Builder builderAnnotation, BuilderInterfaces builderInterfaces) {
+        Map<Element, Annotations> map = new HashMap<>();
+        for (Element element : builderElements) {
             map.put(element, new Annotations(builderAnnotation, builderInterfaces));
         }
         return map;
     }
 
-    private void error(final Element element, final String msg, final Object... args) {
+    private void error(Element element, String msg, Object... args) {
         messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), element);
     }
 

--- a/src/main/java/org/jilt/JiltAnnotationProcessor.java
+++ b/src/main/java/org/jilt/JiltAnnotationProcessor.java
@@ -37,13 +37,13 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        getAnnotatedElements(roundEnv).forEach((annotatedElement, builderAnnotations) -> {
+        for (Map.Entry<Element, Annotations> entry : getAnnotatedElements(roundEnv).entrySet()) {
             try {
-                builderGeneratorFactory.forElement(annotatedElement, builderAnnotations).generateBuilderClass();
+                builderGeneratorFactory.forElement(entry.getKey(), entry.getValue()).generateBuilderClass();
             } catch (Exception e) {
-                error(annotatedElement, e.getMessage());
+                error(entry.getKey(), e.getMessage());
             }
-        });
+        }
 
         return true;
     }
@@ -63,7 +63,7 @@ public class JiltAnnotationProcessor extends AbstractProcessor {
     }
 
     private Map<Element, Annotations> initMap(Set<? extends Element> builderElements, Builder builderAnnotation, BuilderInterfaces builderInterfaces) {
-        Map<Element, Annotations> map = new HashMap<>();
+        Map<Element, Annotations> map = new HashMap<Element, Annotations>();
         for (Element element : builderElements) {
             map.put(element, new Annotations(builderAnnotation, builderInterfaces));
         }

--- a/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
+++ b/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public final class BuilderGeneratorFactory {
     private static final Set<String> ALLOWED_TYPE_KINDS;
     static {
-        ALLOWED_TYPE_KINDS = new HashSet<>(2);
+        ALLOWED_TYPE_KINDS = new HashSet<String>(2);
         ALLOWED_TYPE_KINDS.add(ElementKind.CLASS.name());
         // we don't want to use ElementKind.RECORD because it is not available in Java versions before 16
         ALLOWED_TYPE_KINDS.add("RECORD");
@@ -41,10 +41,10 @@ public final class BuilderGeneratorFactory {
         ExecutableElement targetFactoryMethod = null;
 
         ElementKind kind = annotatedElement.getKind();
-        if (kindIsClassOrRecord(kind)) {
+        if (this.kindIsClassOrRecord(kind)) {
             targetClass = (TypeElement) annotatedElement;
             List<? extends Element> enclosedElements = targetClass.getEnclosedElements();
-            List<VariableElement> fields = new ArrayList<>(enclosedElements.size());
+            List<VariableElement> fields = new ArrayList<VariableElement>(enclosedElements.size());
             for (Element field : enclosedElements) {
                 if (field.getKind() == ElementKind.FIELD &&
                         !field.getModifiers().contains(Modifier.STATIC) &&

--- a/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
+++ b/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
@@ -1,9 +1,9 @@
 package org.jilt.internal;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import org.jilt.Builder;
+import org.jilt.BuilderInterfaces;
+import org.jilt.utils.Annotations;
+
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -13,14 +13,15 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
-import org.jilt.Builder;
-import org.jilt.BuilderInterfaces;
-import org.jilt.utils.Annotations;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public final class BuilderGeneratorFactory {
     private static final Set<String> ALLOWED_TYPE_KINDS;
     static {
-        ALLOWED_TYPE_KINDS = new HashSet<String>(2);
+        ALLOWED_TYPE_KINDS = new HashSet<>(2);
         ALLOWED_TYPE_KINDS.add(ElementKind.CLASS.name());
         // we don't want to use ElementKind.RECORD because it is not available in Java versions before 16
         ALLOWED_TYPE_KINDS.add("RECORD");
@@ -34,16 +35,16 @@ public final class BuilderGeneratorFactory {
         this.elements = elements;
     }
 
-    public BuilderGenerator forElement(final Element annotatedElement, final Annotations annotations) throws Exception {
-        final TypeElement targetClass;
-        final List<? extends VariableElement> attributes;
+    public BuilderGenerator forElement(Element annotatedElement, Annotations annotations) throws Exception {
+        TypeElement targetClass;
+        List<? extends VariableElement> attributes;
         ExecutableElement targetFactoryMethod = null;
 
         ElementKind kind = annotatedElement.getKind();
-        if (this.kindIsClassOrRecord(kind)) {
+        if (kindIsClassOrRecord(kind)) {
             targetClass = (TypeElement) annotatedElement;
             List<? extends Element> enclosedElements = targetClass.getEnclosedElements();
-            List<VariableElement> fields = new ArrayList<VariableElement>(enclosedElements.size());
+            List<VariableElement> fields = new ArrayList<>(enclosedElements.size());
             for (Element field : enclosedElements) {
                 if (field.getKind() == ElementKind.FIELD &&
                         !field.getModifiers().contains(Modifier.STATIC) &&
@@ -66,8 +67,8 @@ public final class BuilderGeneratorFactory {
                     "@Builder can only be placed on classes/records, constructors or static methods");
         }
 
-        final Builder builderAnnotation = annotations.getBuilder() == null ? annotatedElement.getAnnotation(Builder.class) : annotations.getBuilder();
-        final BuilderInterfaces builderInterfaces = annotations.getBuilderInterface() == null ? annotatedElement.getAnnotation(BuilderInterfaces.class) : annotations.getBuilderInterface();
+        Builder builderAnnotation = annotations.getBuilder() == null ? annotatedElement.getAnnotation(Builder.class) : annotations.getBuilder();
+        BuilderInterfaces builderInterfaces = annotations.getBuilderInterface() == null ? annotatedElement.getAnnotation(BuilderInterfaces.class) : annotations.getBuilderInterface();
         switch (builderAnnotation.style()) {
             case STAGED:
             case TYPE_SAFE:

--- a/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
+++ b/src/main/java/org/jilt/internal/BuilderGeneratorFactory.java
@@ -1,8 +1,9 @@
 package org.jilt.internal;
 
-import org.jilt.Builder;
-import org.jilt.BuilderInterfaces;
-
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -12,10 +13,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import org.jilt.Builder;
+import org.jilt.BuilderInterfaces;
+import org.jilt.utils.Annotations;
 
 public final class BuilderGeneratorFactory {
     private static final Set<String> ALLOWED_TYPE_KINDS;
@@ -34,9 +34,9 @@ public final class BuilderGeneratorFactory {
         this.elements = elements;
     }
 
-    public BuilderGenerator forElement(Element annotatedElement) throws Exception {
-        TypeElement targetClass;
-        List<? extends VariableElement> attributes;
+    public BuilderGenerator forElement(final Element annotatedElement, final Annotations annotations) throws Exception {
+        final TypeElement targetClass;
+        final List<? extends VariableElement> attributes;
         ExecutableElement targetFactoryMethod = null;
 
         ElementKind kind = annotatedElement.getKind();
@@ -66,8 +66,8 @@ public final class BuilderGeneratorFactory {
                     "@Builder can only be placed on classes/records, constructors or static methods");
         }
 
-        Builder builderAnnotation = annotatedElement.getAnnotation(Builder.class);
-        BuilderInterfaces builderInterfaces = annotatedElement.getAnnotation(BuilderInterfaces.class);
+        final Builder builderAnnotation = annotations.getBuilder() == null ? annotatedElement.getAnnotation(Builder.class) : annotations.getBuilder();
+        final BuilderInterfaces builderInterfaces = annotations.getBuilderInterface() == null ? annotatedElement.getAnnotation(BuilderInterfaces.class) : annotations.getBuilderInterface();
         switch (builderAnnotation.style()) {
             case STAGED:
             case TYPE_SAFE:

--- a/src/main/java/org/jilt/utils/Annotations.java
+++ b/src/main/java/org/jilt/utils/Annotations.java
@@ -1,0 +1,24 @@
+package org.jilt.utils;
+
+import org.jilt.Builder;
+import org.jilt.BuilderInterfaces;
+
+public final class Annotations {
+
+  private final Builder builder;
+  private final BuilderInterfaces builderInterfaces;
+
+  public Annotations(final Builder builder, final BuilderInterfaces builderInterfaces) {
+    this.builder = builder;
+    this.builderInterfaces = builderInterfaces;
+  }
+
+  public Builder getBuilder() {
+    return builder;
+  }
+
+  public BuilderInterfaces getBuilderInterface() {
+    return builderInterfaces;
+  }
+
+}

--- a/src/main/java/org/jilt/utils/Annotations.java
+++ b/src/main/java/org/jilt/utils/Annotations.java
@@ -4,11 +4,10 @@ import org.jilt.Builder;
 import org.jilt.BuilderInterfaces;
 
 public final class Annotations {
-
   private final Builder builder;
   private final BuilderInterfaces builderInterfaces;
 
-  public Annotations(final Builder builder, final BuilderInterfaces builderInterfaces) {
+  public Annotations(Builder builder, BuilderInterfaces builderInterfaces) {
     this.builder = builder;
     this.builderInterfaces = builderInterfaces;
   }
@@ -20,5 +19,4 @@ public final class Annotations {
   public BuilderInterfaces getBuilderInterface() {
     return builderInterfaces;
   }
-
 }

--- a/src/test/java/org/jilt/test/MetaAnnotationTest.java
+++ b/src/test/java/org/jilt/test/MetaAnnotationTest.java
@@ -1,0 +1,25 @@
+package org.jilt.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jilt.test.data.constructor.MetaConstuctorValue;
+import org.jilt.test.data.constructor.MetaConstuctorValueBuilder;
+import org.junit.Test;
+
+public class MetaAnnotationTest {
+
+  @Test
+  public void test__meta_builder_on_constructor() {
+    final MetaConstuctorValue value = MetaConstuctorValueBuilder.builder()
+        .withAttr2("attr2_value")
+        .withAttr4(4)
+        .withAttr3(true)
+        .build();
+
+    assertThat(value.attr1).isEqualTo(123);
+    assertThat(value.attr2).isEqualTo("attr2_value");
+    assertThat(value.attr3).isTrue();
+    assertThat(value.attr4).isEqualTo(4);
+  }
+
+}

--- a/src/test/java/org/jilt/test/MetaAnnotationTest.java
+++ b/src/test/java/org/jilt/test/MetaAnnotationTest.java
@@ -1,16 +1,15 @@
 package org.jilt.test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jilt.test.data.constructor.MetaConstuctorValue;
-import org.jilt.test.data.constructor.MetaConstuctorValueBuilder;
+import org.jilt.test.data.constructor.MetaConstructorValue;
+import org.jilt.test.data.constructor.MetaConstructorValueBuilder;
 import org.junit.Test;
 
-public class MetaAnnotationTest {
+import static org.assertj.core.api.Assertions.assertThat;
 
+public class MetaAnnotationTest {
   @Test
   public void test__meta_builder_on_constructor() {
-    final MetaConstuctorValue value = MetaConstuctorValueBuilder.builder()
+    MetaConstructorValue value = MetaConstructorValueBuilder.builder()
         .withAttr2("attr2_value")
         .withAttr4(4)
         .withAttr3(true)
@@ -21,5 +20,4 @@ public class MetaAnnotationTest {
     assertThat(value.attr3).isTrue();
     assertThat(value.attr4).isEqualTo(4);
   }
-
 }

--- a/src/test/java/org/jilt/test/data/annotations/MetaBuilder.java
+++ b/src/test/java/org/jilt/test/data/annotations/MetaBuilder.java
@@ -1,0 +1,10 @@
+package org.jilt.test.data.annotations;
+
+import org.jilt.Builder;
+import org.jilt.BuilderInterfaces;
+import org.jilt.BuilderStyle;
+
+@BuilderInterfaces(lastInnerName = "Meta")
+@Builder(setterPrefix = "with", factoryMethod = "builder", style = BuilderStyle.STAGED)
+public @interface MetaBuilder {
+}

--- a/src/test/java/org/jilt/test/data/constructor/MetaConstructorValue.java
+++ b/src/test/java/org/jilt/test/data/constructor/MetaConstructorValue.java
@@ -2,19 +2,17 @@ package org.jilt.test.data.constructor;
 
 import org.jilt.test.data.annotations.MetaBuilder;
 
-public class MetaConstuctorValue {
-
+public class MetaConstructorValue {
   public final int attr1;
   public final String attr2;
   public final boolean attr3;
   public final int attr4;
 
   @MetaBuilder
-  public MetaConstuctorValue(final String attr2, final int attr4, final boolean attr3) {
+  public MetaConstructorValue(String attr2, int attr4, boolean attr3) {
     attr1 = 123;
     this.attr2 = attr2;
     this.attr3 = attr3;
     this.attr4 = attr4;
   }
-
 }

--- a/src/test/java/org/jilt/test/data/constructor/MetaConstuctorValue.java
+++ b/src/test/java/org/jilt/test/data/constructor/MetaConstuctorValue.java
@@ -1,0 +1,20 @@
+package org.jilt.test.data.constructor;
+
+import org.jilt.test.data.annotations.MetaBuilder;
+
+public class MetaConstuctorValue {
+
+  public final int attr1;
+  public final String attr2;
+  public final boolean attr3;
+  public final int attr4;
+
+  @MetaBuilder
+  public MetaConstuctorValue(final String attr2, final int attr4, final boolean attr3) {
+    attr1 = 123;
+    this.attr2 = attr2;
+    this.attr3 = attr3;
+    this.attr4 = attr4;
+  }
+
+}


### PR DESCRIPTION
Please feel free to comment any improvement (I'm sure there are lots). I implemented the best solution I could workout.

The basic idea around this was iterating through the `@Builder` annotated elements. If the element is an annotation, retrieve both `@Builder` and `@BuilderInterfaces` (this one could be optional) and process them exactly the same way this library was already doing.

Fixes #14