### PR TITLE
Fix method builder built as package of return type

### DIFF
--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -468,6 +468,10 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
     }
 
     private String determineTargetClassPackage() {
+        if (this.targetCreationMethod != null) {
+            Element enclosingElement = this.targetCreationMethod.getEnclosingElement();
+            return this.elements.getPackageOf(enclosingElement).getQualifiedName().toString();
+        }
         return this.elements.getPackageOf(this.targetClassType).getQualifiedName().toString();
     }
 


### PR DESCRIPTION
When adding builder to static method with return type, the builder assume the package of the return type, not the enclosing class.

```java
package me.app;
public class App {
    @Builder() public static Integer x(Integer y) { return y; }
}

// generates
package java.lang;
public class IntegerBuilder {
    public Integer build() // ...
}
```
