### PR TITLE
Correct the position of parameter's annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,10 @@ repositories {
     mavenCentral()
 }
 
+if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
+    sourceSets.test.java.exclude '**/AnnotationPosition*.java'
+}
+
 if (JavaVersion.current() <= JavaVersion.VERSION_11) {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ if (JavaVersion.current() <= JavaVersion.VERSION_11) {
 }
 
 dependencies {
-    compileOnly 'com.squareup:javapoet:1.8.0'
+    compileOnly 'com.squareup:javapoet:1.13.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.6.2'

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -338,18 +338,20 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
     }
 
     protected final ParameterSpec setterParameterSpec(VariableElement attribute, TypeName parameterType) {
+        // copy the annotations of type
+        for (AnnotationMirror annotation : attribute.asType().getAnnotationMirrors()) {
+            parameterType = parameterType.annotated(AnnotationSpec.get(annotation));
+        }
+
         ParameterSpec.Builder ret = ParameterSpec
                 .builder(parameterType, this.attributeSimpleName(attribute))
                 .addModifiers(Modifier.FINAL);
 
-        // copy the relevant annotations
+        // copy the annotations of parameter
         for (AnnotationMirror annotation : attribute.getAnnotationMirrors()) {
             if (this.isAnnotationAllowedOnParam(annotation)) {
                 ret.addAnnotation(AnnotationSpec.get(annotation));
             }
-        }
-        for (AnnotationMirror annotation : attribute.asType().getAnnotationMirrors()) {
-            ret.addAnnotation(AnnotationSpec.get(annotation));
         }
 
         return ret.build();

--- a/src/test/java/org/jilt/test/AnnotationPositionTest.java
+++ b/src/test/java/org/jilt/test/AnnotationPositionTest.java
@@ -2,6 +2,7 @@ package org.jilt.test;
 
 import org.jilt.test.data.annotation_position.TypeUseOnlyAnnotation;
 import org.jilt.test.data.annotation_position.TypeUseOnlyBuilder;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -12,8 +13,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AnnotationPositionTest {
     @Test
     public void test_type_use_annotation_on_correct_position() throws NoSuchMethodException {
+        int jreVersion = getJreVersion();
+
+        // Java 8 has some bugs in Language Model API, see https://bugs.openjdk.org/browse/JDK-8031744
+        // Therefore, Jilt cannot correctly detect TYPE_USE-only annotations.
+        Assume.assumeTrue(jreVersion >= 9);
+
         Method typeUseSetter = TypeUseOnlyBuilder.class.getMethod("typeUse", Map.Entry.class);
 
-        assertThat(typeUseSetter.getAnnotatedParameterTypes()[0].isAnnotationPresent(TypeUseOnlyAnnotation.class)).isTrue();
+        if (jreVersion < 13) {
+            assertThat(
+                    typeUseSetter
+                            .getAnnotatedParameterTypes()[0]
+                            // Before Java 13, the Reflect API
+                            // cannot correctly handle the annotation on static inner class,
+                            // it will push annotations to 'OwnerType'
+                            // see https://bugs.openjdk.org/browse/JDK-8198526
+                            .getAnnotatedOwnerType() // ! @since 9
+                            .isAnnotationPresent(TypeUseOnlyAnnotation.class)
+            ).isTrue();
+
+        } else {
+            assertThat(
+                    typeUseSetter
+                            .getAnnotatedParameterTypes()[0]
+                            .isAnnotationPresent(TypeUseOnlyAnnotation.class)
+            ).isTrue();
+        }
+    }
+
+    private int getJreVersion() {
+        String[] versionElements = System.getProperty("java.version").split("\\.");
+
+        int discard = Integer.parseInt(versionElements[0]);
+
+        int version;
+        if (discard == 1) {
+            version = Integer.parseInt(versionElements[1]);
+        } else {
+            version = discard;
+        }
+
+        return version;
     }
 }

--- a/src/test/java/org/jilt/test/AnnotationPositionTest.java
+++ b/src/test/java/org/jilt/test/AnnotationPositionTest.java
@@ -1,0 +1,19 @@
+package org.jilt.test;
+
+import org.jilt.test.data.annotation_position.TypeUseOnlyAnnotation;
+import org.jilt.test.data.annotation_position.TypeUseOnlyBuilder;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnotationPositionTest {
+    @Test
+    public void test_type_use_annotation_on_correct_position() throws NoSuchMethodException {
+        Method typeUseSetter = TypeUseOnlyBuilder.class.getMethod("typeUse", Map.Entry.class);
+
+        assertThat(typeUseSetter.getAnnotatedParameterTypes()[0].isAnnotationPresent(TypeUseOnlyAnnotation.class)).isTrue();
+    }
+}

--- a/src/test/java/org/jilt/test/data/annotation_position/TypeUseOnly.java
+++ b/src/test/java/org/jilt/test/data/annotation_position/TypeUseOnly.java
@@ -1,0 +1,19 @@
+package org.jilt.test.data.annotation_position;
+
+import org.jilt.Builder;
+import org.jilt.BuilderStyle;
+
+import java.util.Map;
+
+public class TypeUseOnly {
+    private final Map.@TypeUseOnlyAnnotation Entry<Integer, Integer> typeUse;
+
+    @Builder(style = BuilderStyle.STAGED)
+    public TypeUseOnly(Map.@TypeUseOnlyAnnotation Entry<Integer, Integer> typeUse) {
+        this.typeUse = typeUse;
+    }
+
+    public Map.@TypeUseOnlyAnnotation Entry<Integer, Integer> getTypeUse() {
+        return typeUse;
+    }
+}

--- a/src/test/java/org/jilt/test/data/annotation_position/TypeUseOnlyAnnotation.java
+++ b/src/test/java/org/jilt/test/data/annotation_position/TypeUseOnlyAnnotation.java
@@ -1,0 +1,11 @@
+package org.jilt.test.data.annotation_position;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TypeUseOnlyAnnotation {
+}


### PR DESCRIPTION
* `jspecify` defines `@Nullable` as `@Target(TYPE_USE)`. Previously `jilt` generates `public Builder middleName(@Nullable final String middleName)`, which places `@Nullable` to a wrong position.

* `javapoet` 1.8.0 also cannot generate correct codes, see https://github.com/square/javapoet/issues/431