### PR TITLE
Fix writing incorrect @Generated annotation when using "--release 8" as compiler arg

### DIFF
--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -493,20 +493,20 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         return this.targetCreationMethod.getModifiers().contains(Modifier.PRIVATE);
     }
 
-    protected final AnnotationSpec generatedAnnotation() throws Exception {
-        Class<?> generatedAnnotationClass = determineGeneratedAnnotationClass();
+    protected final AnnotationSpec generatedAnnotation() {
+        ClassName generatedAnnotationClass = determineGeneratedAnnotationClass();
         return AnnotationSpec
                 .builder(generatedAnnotationClass)
                 .addMember("value", "$S", "Jilt-1.6.2")
                 .build();
     }
 
-    private Class<?> determineGeneratedAnnotationClass() throws Exception {
-        try {
-            // available since 9
-            return Class.forName("javax.annotation.processing.Generated");
-        } catch (ClassNotFoundException e) {
-            return Class.forName("javax.annotation.Generated");
+    private ClassName determineGeneratedAnnotationClass() {
+        TypeElement generatedAnnotation = this.elements.getTypeElement("javax.annotation.processing.Generated");
+        if (generatedAnnotation == null) {
+            generatedAnnotation = this.elements.getTypeElement("javax.annotation.Generated");
         }
+
+        return ClassName.get(generatedAnnotation);
     }
 }

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -503,10 +503,8 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
 
     private ClassName determineGeneratedAnnotationClass() {
         TypeElement generatedAnnotation = this.elements.getTypeElement("javax.annotation.processing.Generated");
-        if (generatedAnnotation == null) {
-            generatedAnnotation = this.elements.getTypeElement("javax.annotation.Generated");
-        }
-
-        return ClassName.get(generatedAnnotation);
+        return ClassName.get(generatedAnnotation == null
+            ? this.elements.getTypeElement("javax.annotation.Generated")
+            : generatedAnnotation);
     }
 }


### PR DESCRIPTION
#### Problem
`javax.annotation.processing.Generated` is not available for compilation when using --release 8 as compiler arg but it is in the classpath so the annotation processor will use it.

#### Solution
The `Elements` object respects the "--release 8" compiler argument returning `null` for `javax.annotation.processing.Generated`  when it is set and the type element when it is not.