### PR TITLE
Add support for '*' in `@Builder.className`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -595,6 +595,22 @@ public final class MyValueClass {
 }
 ```
 
+If you want to change the name of the generated Builder class with a meta-annotation,
+you typically need that name to depend on the name of the class being built,
+not just be a constant string
+(since that's likely to cause conflicts if the meta-annotation is used more than once).
+Because of that, similarly to `@BuilderInterfaces.innerName`,
+`@Builder.className` allows using the `*` character as a placeholder for the name of the built class,
+so you could define the meta-annotation like this:
+
+```java
+import org.jilt.Builder;
+
+@Builder(className = "*JiltBuilder")
+public @interface MyBuilder {
+}
+```
+
 **Note**: since Jilt is implemented as a Java annotation processor,
 that means it shares the limitations common to all annotation processors.
 The restriction that is most relevant to meta-annotation support is that only files from a single source set

--- a/src/main/java/org/jilt/Builder.java
+++ b/src/main/java/org/jilt/Builder.java
@@ -244,9 +244,13 @@ public @interface Builder {
      * Allows declaring what should be the name of the generated Builder class.
      * Must be a valid Java (top-level) class name.
      * <p>
-     * This is an optional attribute - the default is <code>&lt;TargetClass&gt;Builder</code>
-     * (so, for example, if we're building an instance of a <code>Person</code> class,
-     * the default name will be <code>PersonBuilder</code>).
+     * When used for creating a meta-annotation by placing {@link Builder} on a different annotation,
+     * you can use the {@code *} character as a placeholder for the name of the target class.
+     * <p>
+     * This is an optional attribute - the default is {@code <TargetClassName>Builder},
+     * same as {@code *Builder}
+     * (so, for example, if we're building an instance of a {@code Person} class,
+     * the default name will be {@code PersonBuilder}).
      */
     String className() default "";
 

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -397,7 +397,8 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         String annotationBuilderClassName = builderAnnotation.className();
         return annotationBuilderClassName.isEmpty()
                 ? this.targetClassSimpleName() + "Builder"
-                : annotationBuilderClassName;
+                // we need to replace any '*' in className with the target class's name
+                : annotationBuilderClassName.replaceAll("\\*", this.targetClassSimpleName().toString());
     }
 
     protected final Filer filer() {

--- a/src/test/java/org/jilt/test/MetaAnnotationsTest.java
+++ b/src/test/java/org/jilt/test/MetaAnnotationsTest.java
@@ -1,8 +1,8 @@
 package org.jilt.test;
 
 import org.jilt.test.data.meta.MetaConstructorValue;
-import org.jilt.test.data.meta.MetaConstructorValueBuilder;
-import org.jilt.test.data.meta.MetaConstructorValueBuilders.Meta;
+import org.jilt.test.data.meta.MetaConstructorValueJiltBuilder;
+import org.jilt.test.data.meta.MetaConstructorValueJiltBuilders.Meta;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MetaAnnotationsTest {
     @Test
     public void test_meta_builder_on_constructor() {
-        Meta lastValue = MetaConstructorValueBuilder.builder()
+        Meta lastValue = MetaConstructorValueJiltBuilder.builder()
                 .withAttr2("attr2_value")
                 .withAttr4(4)
                 .withAttr3(true);

--- a/src/test/java/org/jilt/test/data/meta/MetaBuilder.java
+++ b/src/test/java/org/jilt/test/data/meta/MetaBuilder.java
@@ -5,6 +5,6 @@ import org.jilt.BuilderInterfaces;
 import org.jilt.BuilderStyle;
 
 @BuilderInterfaces(lastInnerName = "Meta")
-@Builder(setterPrefix = "with", factoryMethod = "builder", style = BuilderStyle.STAGED)
+@Builder(setterPrefix = "with", factoryMethod = "builder", style = BuilderStyle.STAGED, className = "*JiltBuilder")
 public @interface MetaBuilder {
 }

--- a/src/test/java/org/jilt/test/data/typesafe_ungrouped/TypeSafeValue.java
+++ b/src/test/java/org/jilt/test/data/typesafe_ungrouped/TypeSafeValue.java
@@ -6,14 +6,13 @@ import org.jilt.BuilderStyle;
 
 @Builder(
         style = BuilderStyle.TYPE_SAFE_UNGROUPED_OPTIONALS,
-        className = "TypeSafeValueCreator",
+        className = "*Creator",
         packageName = "org.jilt.test.data.typesafe_ungrouped.custom",
         setterPrefix = "with",
         factoryMethod = "creator",
         buildMethod = "create"
 )
 @BuilderInterfaces(
-        outerName = "TypeSafeValueCreators",
         packageName = "org.jilt.test.data.typesafe_ungrouped.custom.customer",
         innerNames = "Step_*"
 )


### PR DESCRIPTION
See [this comment](https://github.com/skinny85/jilt/issues/28#issuecomment-2638853887)
for a detailed justification of this feature.
