### PR TITLE
Upgrade JSpecify to `1.0.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ if (JavaVersion.current() < JavaVersion.VERSION_17) {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
     dependencies {
-        testImplementation 'org.jspecify:jspecify:0.3.0'
+        testImplementation 'org.jspecify:jspecify:1.0.0'
     }
 }
 


### PR DESCRIPTION
[JSpecify 1.0.0 has been released 1 year ago](https://jspecify.dev/blog/release-1.0.0/). I think, it's time to update. 