### PR TITLE
Copy JavaDocs to the generated setters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ group 'cc.jilt' // we need a domain we own for Maven Central, and jilt.org is sc
 version '1.8.4'
 
 shadowJar {
-    relocate 'com.squareup', 'org.jilt.shaded.com.squareup'
+    relocate 'com', 'org.jilt.shaded.com'
 
     archiveClassifier = '' // we want the shadow JAR to be the main output JAR
     configurations = [project.configurations.compileClasspath]
@@ -99,7 +99,9 @@ if (JavaVersion.current() < JavaVersion.VERSION_17) {
 
 dependencies {
     compileOnly 'com.squareup:javapoet:1.13.0'
+    compileOnly 'com.github.javaparser:javaparser-core:3.27.1'
 
+    testImplementation 'com.github.javaparser:javaparser-core:3.27.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.27.6'
     testImplementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -1,5 +1,8 @@
 package org.jilt.internal;
 
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.javadoc.Javadoc;
+import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -317,6 +320,13 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
                         // where we chain methods of the Builder class directly)
                         : this.builderClassTypeName())
                 .addParameter(this.setterParameterSpec(attribute, parameterType));
+
+        // copy JavaDoc for the property (if there was any) to the setter
+        String elementJavadoc = this.getAttributeJavadoc(attribute);
+        if (elementJavadoc != null) {
+            setter.addJavadoc(elementJavadoc);
+        }
+
         if (abstractMethod) {
             setter.addModifiers(Modifier.ABSTRACT);
         } else {
@@ -327,6 +337,31 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         }
 
         return setter.build();
+    }
+
+    protected final String getAttributeJavadoc(VariableElement attribute) {
+        String elementJavadoc;
+        if (this.targetCreationMethod == null && this.annotatedElement.getKind() == ElementKind.CLASS) {
+            // this means @Builder was placed on a class -
+            // so, in this case, we just copy the JavaDoc from the field
+            elementJavadoc = this.elements.getDocComment(attribute);
+        } else {
+            elementJavadoc = null;
+            String creationMethodJavadocStr = this.elements.getDocComment(this.targetCreationMethod == null
+                // this means @Builder was placed on a Record class
+                ? this.annotatedElement
+                : this.targetCreationMethod);
+            if (creationMethodJavadocStr != null) {
+                Javadoc javadoc = StaticJavaParser.parseJavadoc(creationMethodJavadocStr);
+                for (JavadocBlockTag blockTag : javadoc.getBlockTags()) {
+                    if ("param".equals(blockTag.getTagName()) &&
+                            attribute.getSimpleName().toString().equals(blockTag.getName().orElse(""))) {
+                        elementJavadoc = blockTag.getContent().toText();
+                    }
+                }
+            }
+        }
+        return elementJavadoc;
     }
 
     protected abstract TypeName returnTypeForSetterFor(VariableElement attribute, boolean withMangledTypeParameters);

--- a/src/main/java/org/jilt/internal/FunctionalBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/FunctionalBuilderGenerator.java
@@ -179,7 +179,7 @@ final class FunctionalBuilderGenerator extends AbstractTypeSafeBuilderGenerator 
         }
 
         TypeName parameterType = this.attributeType(attribute, mangleTypeParameters);
-        return MethodSpec
+        MethodSpec.Builder setter = MethodSpec
                 .methodBuilder(this.setterMethodName(attribute))
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addTypeVariables(this.builderClassTypeParameters())
@@ -187,8 +187,15 @@ final class FunctionalBuilderGenerator extends AbstractTypeSafeBuilderGenerator 
                 .addParameter(this.setterParameterSpec(attribute, parameterType))
                 .addStatement("return $1L -> $1L.$2L = $2L",
                         this.builderClassMethodParamName(),
-                        this.attributeSimpleName(attribute))
-                .build();
+                        this.attributeSimpleName(attribute));
+
+        // copy JavaDoc for the property (if there was any) to the setter
+        String elementJavadoc = this.getAttributeJavadoc(attribute);
+        if (elementJavadoc != null) {
+            setter.addJavadoc(elementJavadoc);
+        }
+
+        return setter.build();
     }
 
     @Override

--- a/src/test/java/org/jilt/test/AbstractJavadocTest.java
+++ b/src/test/java/org/jilt/test/AbstractJavadocTest.java
@@ -1,0 +1,44 @@
+package org.jilt.test;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.javadoc.Javadoc;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractJavadocTest {
+    protected Optional<String> getSetterJavadoc(String javaFilePath, String setterName) throws FileNotFoundException {
+        return this.getSetterJavadoc(javaFilePath, null,  setterName);
+    }
+
+    protected Optional<String> getSetterJavadoc(String javaFilePath, String innerTypeName, String setterName)
+            throws FileNotFoundException {
+        CompilationUnit compilationUnit = StaticJavaParser.parse(new File(
+                "build/generated/sources/annotationProcessor/java/test/" + javaFilePath));
+        TypeDeclaration<?> typeDeclaration = compilationUnit.getPrimaryType().get();
+
+        List<MethodDeclaration> setters = typeDeclaration.getMethodsByName(setterName);
+        if (innerTypeName != null) {
+            for (BodyDeclaration<?> member : typeDeclaration.getMembers()) {
+                if (member.isTypeDeclaration()) {
+                    TypeDeclaration<?> nestedType = member.toTypeDeclaration().get();
+                    if (innerTypeName.equals(nestedType.getName().asString())) {
+                        setters = nestedType.getMethodsByName(setterName);
+                    }
+                }
+            }
+        }
+
+        assertThat(setters).hasSize(1);
+        MethodDeclaration setter = setters.get(0);
+        return setter.getJavadoc().map(Javadoc::toText);
+    }
+}

--- a/src/test/java/org/jilt/test/JavadocTest.java
+++ b/src/test/java/org/jilt/test/JavadocTest.java
@@ -1,0 +1,46 @@
+package org.jilt.test;
+
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavadocTest extends AbstractJavadocTest {
+    @Test
+    public void classic_Builder_on_classes_copies_field_Javadocs_to_Builder_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/classic/ClassicValueBuilder.java", "securityAnswers");
+        assertThat(setterJavadoc).hasValue("Example JavaDoc for field {@link #securityAnswers}.\n");
+    }
+
+    @Test
+    public void staged_Builder_on_constructors_copies_param_tag_Javadocs_to_Builder_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/tobuilder/UserBuilder.java", "lastName");
+        assertThat(setterJavadoc).hasValue("example JavaDoc for lastName parameter\n");
+    }
+
+    @Test
+    public void staged_Builder_on_constructors_copies_param_tag_Javadocs_to_interface_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/tobuilder/UserBuilders.java", "LastName", "lastName");
+        assertThat(setterJavadoc).hasValue("example JavaDoc for lastName parameter\n");
+    }
+
+    @Test
+    public void staged_ordered_Builder_on_static_methods_copies_param_tag_Javadocs_to_Builder_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/generic/Generic3TypeParamsBuilder.java", "b");
+        assertThat(setterJavadoc).hasValue("example JavaDoc for parameter b\n          (with multiple lines)\n");
+    }
+
+    @Test
+    public void staged_ordered_Builder_on_static_methods_copies_param_tag_Javadocs_to_interface_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/generic/Generic3TypeParamsBuilders.java", "B", "b");
+        assertThat(setterJavadoc).hasValue("example JavaDoc for parameter b\n          (with multiple lines)\n");
+    }
+
+    @Test
+    public void functional_Builder_on_classes_copies_field_Javadocs_to_Builder_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/functional/LargeLanguageModelBuilder.java", "name");
+        assertThat(setterJavadoc).hasValue("example JavaDoc of the {@link LargeLanguageModel#name} field\n");
+    }
+}

--- a/src/test/java/org/jilt/test/RecordJavadocTest.java
+++ b/src/test/java/org/jilt/test/RecordJavadocTest.java
@@ -1,0 +1,22 @@
+package org.jilt.test;
+
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordJavadocTest extends AbstractJavadocTest {
+    @Test
+    public void staged_Builder_on_records_copies_param_tag_Javadocs_to_Builder_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/record/RecordNoWorkaroundBuilder.java", "age");
+        assertThat(setterJavadoc).hasValue("Example JavaDoc of the {@code age} parameter.\n");
+    }
+
+    @Test
+    public void staged_Builder_on_records_copies_param_tag_Javadocs_to_interface_setters() throws FileNotFoundException {
+        Optional<String> setterJavadoc = this.getSetterJavadoc("org/jilt/test/data/record/RecordNoWorkaroundBuilders.java", "Age", "age");
+        assertThat(setterJavadoc).hasValue("Example JavaDoc of the {@code age} parameter.\n");
+    }
+}

--- a/src/test/java/org/jilt/test/data/classic/ClassicValue.java
+++ b/src/test/java/org/jilt/test/data/classic/ClassicValue.java
@@ -9,9 +9,16 @@ import java.util.List;
 public class ClassicValue {
     private static String staticName;
 
+    /** Example JavaDoc for field {@link #name}. */
     private final String name;
+
+    /** Example JavaDoc for field {@link #age}. */
     private final int age;
+
+    /** Example JavaDoc for field {@link #nick}. */
     private final String nick;
+
+    /** Example JavaDoc for field {@link #securityAnswers}. */
     private final List<String> securityAnswers;
 
     {

--- a/src/test/java/org/jilt/test/data/functional/LargeLanguageModel.java
+++ b/src/test/java/org/jilt/test/data/functional/LargeLanguageModel.java
@@ -7,6 +7,7 @@ import org.jilt.BuilderStyle;
 @Builder(style = BuilderStyle.FUNCTIONAL, toBuilder = "toBuilder", buildMethod = "create")
 @BuilderInterfaces(outerName = "LargeLanguageModelBuilderInterfaces")
 public final class LargeLanguageModel {
+    /** example JavaDoc of the {@link LargeLanguageModel#name} field */
     public final String name;
     public final float temperature;
     public final int outputTokensLimit;

--- a/src/test/java/org/jilt/test/data/generic/Generic3TypeParams.java
+++ b/src/test/java/org/jilt/test/data/generic/Generic3TypeParams.java
@@ -5,6 +5,17 @@ import org.jilt.BuilderStyle;
 import org.jilt.Opt;
 
 public final class Generic3TypeParams<A, B, C> {
+    /**
+     * Example JavaDoc.
+     *
+     * @param a example JavaDoc for parameter a
+     * @param b example JavaDoc for parameter b
+     *          (with multiple lines)
+     * @param c example JavaDoc for parameter c
+     * @return an instance of {@link Generic3TypeParams}
+     * @param <B> first example type parameter (for parameter b)
+     * @param <C> second example type parameter (for parameter c)
+     */
     @Builder(style = BuilderStyle.STAGED_PRESERVING_ORDER)
     public static <B, C> Generic3TypeParams<?, B, C> make(Character a, @Opt B b, C c) {
         return new Generic3TypeParams<Character, B, C>(a, b, c);

--- a/src/test/java/org/jilt/test/data/record/RecordNoWorkaround.java
+++ b/src/test/java/org/jilt/test/data/record/RecordNoWorkaround.java
@@ -4,6 +4,12 @@ import org.jilt.Builder;
 import org.jilt.BuilderStyle;
 import org.jilt.Opt;
 
+/**
+ * Example JavaDoc for a record class.
+ *
+ * @param name Example JavaDoc of the {@code name} parameter.
+ * @param age Example JavaDoc of the {@code age} parameter.
+ */
 @Builder(style = BuilderStyle.STAGED, toBuilder = "copy")
 public record RecordNoWorkaround(@Opt String name, int age) {
 }

--- a/src/test/java/org/jilt/test/data/tobuilder/User.java
+++ b/src/test/java/org/jilt/test/data/tobuilder/User.java
@@ -7,6 +7,15 @@ import org.jilt.Opt;
 public final class User {
     public final String email, username, firstName, lastName, displayName;
 
+    /**
+     * Example JavaDoc of constructor of {@link User}.
+     *
+     * @param email example JavaDoc for email parameter
+     * @param username example JavaDoc for username parameter
+     * @param firstName example JavaDoc for firstName parameter
+     * @param lastName example JavaDoc for lastName parameter
+     * @param displayName example JavaDoc for displayName parameter
+     */
     @Builder(style = BuilderStyle.STAGED, toBuilder = "modifiedUser")
     public User(String email, @Opt String username, String firstName,
             String lastName, @Opt String displayName) {


### PR DESCRIPTION
Make Jilt copy JavaDocs to the generated Builder setter methods.

The copying has the following logic:

- If `@Builder` was placed on a Record, constructor, or static method,
  the JavaDoc copied will be taken from the `@param`
  tag with the same name as the name of the setter property (if found).
- If `@Builder` was placed on a class,
  the JavaDoc copied will be taken from the JavaDoc of the field
  corresponding to the setter property.

The JavaDocs are copied both to the setters of the Builder class,
and also to the setters of the Staged Builder interfaces
(if one of the two Staged Builder styles was used).

Fixes #72
