### PR TITLE
Handle getters returning Optional for nullable fields in toBuilder

### DIFF
--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -242,7 +242,8 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         // 2. The record read method (xyz())
         // 3. The field itself (xyz)
         String getterMethod = "get" + capitalizedFieldName ;
-        boolean getterFound = false, onlyGetterOptional = false, recordReaderFound = false, publicFieldFound = false;
+        boolean getterFound = false, recordReaderFound = false, publicFieldFound = false;
+        boolean onlyClassicGetterOptional = false, onlyRecordGetterOptional = false;
 
         if (this.targetClassTypeElement != null) {
             for (Element member : this.elements.getAllMembers(this.targetClassTypeElement)) {
@@ -252,7 +253,7 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
                     // but the field is of type T
                     if (!attributeIsTypeOpt &&
                             this.typeIsJavaUtilOptional(((ExecutableElement) member).getReturnType())) {
-                        onlyGetterOptional = true;
+                        onlyClassicGetterOptional = true;
                     }
                 }
                 if (elementIsMethodWithoutArgumentsCalled(member, "is" + capitalizedFieldName)) {
@@ -265,7 +266,7 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
                     // but the field is of type T
                     if (!attributeIsTypeOpt &&
                             this.typeIsJavaUtilOptional(((ExecutableElement) member).getReturnType())) {
-                        onlyGetterOptional = true;
+                        onlyRecordGetterOptional = true;
                     }
                 }
                 if (member.getKind() == ElementKind.FIELD &&
@@ -277,10 +278,10 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         }
         if (getterFound) {
             // we always prefer the getter if we found one
-            return getterMethod + "()" + (onlyGetterOptional ? ".orElse(null)" : "");
+            return getterMethod + "()" + (onlyClassicGetterOptional ? ".orElse(null)" : "");
         } else if (recordReaderFound) {
             // if there's no getter, but there's a record-style read method, use that
-            return fieldName + "()" + (onlyGetterOptional ? ".orElse(null)" : "");
+            return fieldName + "()" + (onlyRecordGetterOptional ? ".orElse(null)" : "");
         } else if (publicFieldFound) {
             // if there's no getter or record-style reader,
             // but the field is public, simply use the field itself

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -261,6 +261,12 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
                 }
                 if (elementIsMethodWithoutArgumentsCalled(member, fieldName)) {
                     recordReaderFound = true;
+                    // special case: recrod-style getter that returns Optional<T>,
+                    // but the field is of type T
+                    if (!attributeIsTypeOpt &&
+                            this.typeIsJavaUtilOptional(((ExecutableElement) member).getReturnType())) {
+                        onlyGetterOptional = true;
+                    }
                 }
                 if (member.getKind() == ElementKind.FIELD &&
                         member.getSimpleName().toString().equals(fieldName) &&
@@ -274,7 +280,7 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
             return getterMethod + "()" + (onlyGetterOptional ? ".orElse(null)" : "");
         } else if (recordReaderFound) {
             // if there's no getter, but there's a record-style read method, use that
-            return fieldName + "()";
+            return fieldName + "()" + (onlyGetterOptional ? ".orElse(null)" : "");
         } else if (publicFieldFound) {
             // if there's no getter or record-style reader,
             // but the field is public, simply use the field itself

--- a/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
+++ b/src/main/java/org/jilt/internal/AbstractBuilderGenerator.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 abstract class AbstractBuilderGenerator implements BuilderGenerator {
+    private static final ClassName JAVA_UTIL_OPTIONAL = ClassName.get("java.util", "Optional");
+
     protected final Element annotatedElement;
     private final Elements elements;
     private final Filer filer;
@@ -231,20 +233,27 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
     }
 
     protected final String accessAttributeOfTargetClass(VariableElement attribute) {
-        String fieldName = this.attributeSimpleName(attribute);
-        String capitalizedFieldName = Utils.capitalize(fieldName);
+        final String fieldName = this.attributeSimpleName(attribute);
+        final String capitalizedFieldName = Utils.capitalize(fieldName);
+        final boolean attributeIsTypeOpt = this.typeIsJavaUtilOptional(attribute.asType());
 
         // candidates are:
         // 1. The getter method (getXyz() / isXyz())
         // 2. The record read method (xyz())
         // 3. The field itself (xyz)
         String getterMethod = "get" + capitalizedFieldName ;
-        boolean getterFound = false, recordReaderFound = false, publicFieldFound = false;
+        boolean getterFound = false, onlyGetterOptional = false, recordReaderFound = false, publicFieldFound = false;
 
         if (this.targetClassTypeElement != null) {
             for (Element member : this.elements.getAllMembers(this.targetClassTypeElement)) {
                 if (elementIsMethodWithoutArgumentsCalled(member, getterMethod)) {
                     getterFound = true;
+                    // special case: getter that returns Optional<T>,
+                    // but the field is of type T
+                    if (!attributeIsTypeOpt &&
+                            this.typeIsJavaUtilOptional(((ExecutableElement) member).getReturnType())) {
+                        onlyGetterOptional = true;
+                    }
                 }
                 if (elementIsMethodWithoutArgumentsCalled(member, "is" + capitalizedFieldName)) {
                     getterFound = true;
@@ -262,7 +271,7 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
         }
         if (getterFound) {
             // we always prefer the getter if we found one
-            return getterMethod + "()";
+            return getterMethod + "()" + (onlyGetterOptional ? ".orElse(null)" : "");
         } else if (recordReaderFound) {
             // if there's no getter, but there's a record-style read method, use that
             return fieldName + "()";
@@ -279,6 +288,15 @@ abstract class AbstractBuilderGenerator implements BuilderGenerator {
             String getterPrefix = attribute.asType().getKind() == TypeKind.BOOLEAN ? "is" : "get";
             return getterPrefix + capitalizedFieldName + "()";
         }
+    }
+
+    private boolean typeIsJavaUtilOptional(TypeMirror type) {
+        TypeName typeName = TypeName.get(type);
+        if (typeName instanceof ParameterizedTypeName) {
+            // typically java.util.Optional is a parametrized type
+            typeName = ((ParameterizedTypeName) typeName).rawType;
+        }
+        return typeName.equals(JAVA_UTIL_OPTIONAL);
     }
 
     private static boolean elementIsMethodWithoutArgumentsCalled(Element element, String methodName) {

--- a/src/test/java/org/jilt/test/OptionalsValueTest.java
+++ b/src/test/java/org/jilt/test/OptionalsValueTest.java
@@ -5,6 +5,8 @@ import org.jilt.test.data.optionals.OptionalGetterValue;
 import org.jilt.test.data.optionals.OptionalGetterValueBuilder;
 import org.jilt.test.data.optionals.OptionalsRawValue;
 import org.jilt.test.data.optionals.OptionalsRawValueBuilder;
+import org.jilt.test.data.optionals.OptionalsRecordGetterValue;
+import org.jilt.test.data.optionals.OptionalsRecordGetterValueBuilder;
 import org.jilt.test.data.optionals.OptionalsValue;
 import org.jilt.test.data.optionals.OptionalsValueBuilder;
 import org.jilt.test.data.optionals.OptionalsWildcardValue;
@@ -95,5 +97,19 @@ public class OptionalsValueTest {
                 .build();
 
         assertThat(value2.getStrValue()).isEmpty();
+    }
+
+    @Test
+    public void record_style_getter_returning_Optional_works_with_toBuilder() {
+        OptionalsRecordGetterValue value1 = OptionalsRecordGetterValueBuilder.optionalsRecordGetterValue()
+                .object(null)
+                .optionalString(Optional.empty())
+                .build();
+
+        OptionalsRecordGetterValue value2 = OptionalsRecordGetterValueBuilder.toBuilder(value1)
+                .build();
+
+        assertThat(value2.object()).isEmpty();
+        assertThat(value2.optionalString()).isEmpty();
     }
 }

--- a/src/test/java/org/jilt/test/OptionalsValueTest.java
+++ b/src/test/java/org/jilt/test/OptionalsValueTest.java
@@ -1,6 +1,8 @@
 package org.jilt.test;
 
 import org.jilt.test.data.optionals.NullableOptionalsWithOrderValueBuilder;
+import org.jilt.test.data.optionals.OptionalGetterValue;
+import org.jilt.test.data.optionals.OptionalGetterValueBuilder;
 import org.jilt.test.data.optionals.OptionalsRawValue;
 import org.jilt.test.data.optionals.OptionalsRawValueBuilder;
 import org.jilt.test.data.optionals.OptionalsValue;
@@ -24,8 +26,21 @@ public class OptionalsValueTest {
                 .v(null)
                 .build();
 
-        assertThat(value.optional).contains("abc");
+        assertThat(value.getOptional()).contains("abc");
         assertThat(value.v).isNull();
+    }
+    @Test
+    public void Optional_type_property_can_be_null() {
+        OptionalsValue<String> value1 = OptionalsValueBuilder.<String>optionalsValue()
+                .optional(null)
+                .v(null)
+                .build();
+
+        OptionalsValue<String> value2 = OptionalsValueBuilder.toBuilder(value1)
+                .build();
+
+        assertThat(value2.getOptional()).isNull();
+        assertThat(value2.v).isNull();
     }
 
     @Test
@@ -68,5 +83,17 @@ public class OptionalsValueTest {
 
         assertThat(value.optional).isEmpty();
         assertThat(value.v).isNull();
+    }
+
+    @Test
+    public void getter_returning_Optional_works_with_toBuilder() {
+        OptionalGetterValue value1 = OptionalGetterValueBuilder.optionalGetterValue()
+                .withStrValue(null)
+                .build();
+
+        OptionalGetterValue value2 = OptionalGetterValueBuilder.toBuilder(value1)
+                .build();
+
+        assertThat(value2.getStrValue()).isEmpty();
     }
 }

--- a/src/test/java/org/jilt/test/data/optionals/OptionalGetterValue.java
+++ b/src/test/java/org/jilt/test/data/optionals/OptionalGetterValue.java
@@ -1,0 +1,22 @@
+package org.jilt.test.data.optionals;
+
+import org.jilt.Builder;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Builder(setterPrefix = "with", toBuilder = "toBuilder")
+public final class OptionalGetterValue {
+    @Nullable
+    private final String strValue;
+
+    public OptionalGetterValue(@Nullable String strValue) {
+        this.strValue = strValue;
+    }
+
+    @Nonnull
+    public Optional<String> getStrValue() {
+        return Optional.ofNullable(this.strValue);
+    }
+}

--- a/src/test/java/org/jilt/test/data/optionals/OptionalsRecordGetterValue.java
+++ b/src/test/java/org/jilt/test/data/optionals/OptionalsRecordGetterValue.java
@@ -1,0 +1,27 @@
+package org.jilt.test.data.optionals;
+
+import org.jilt.Builder;
+import org.jilt.BuilderStyle;
+
+import java.util.Optional;
+
+public final class OptionalsRecordGetterValue {
+    private final Object object;
+    private final Optional<String> optionalString;
+
+    @Builder(style = BuilderStyle.STAGED, toBuilder = "toBuilder")
+    public OptionalsRecordGetterValue(Object object, Optional<String> optionalString) {
+        this.object = object;
+        this.optionalString = optionalString;
+    }
+
+    /** Test handling of a raw Optional. */
+    @SuppressWarnings("rawtypes")
+    public Optional object() {
+        return Optional.ofNullable(this.object);
+    }
+
+    public Optional<String> optionalString() {
+        return this.optionalString;
+    }
+}

--- a/src/test/java/org/jilt/test/data/optionals/OptionalsValue.java
+++ b/src/test/java/org/jilt/test/data/optionals/OptionalsValue.java
@@ -5,13 +5,17 @@ import org.jilt.BuilderStyle;
 
 import java.util.Optional;
 
-@Builder(style = BuilderStyle.STAGED)
+@Builder(style = BuilderStyle.STAGED, toBuilder = "toBuilder")
 public final class OptionalsValue<T> {
-    public final Optional<T> optional;
+    private final Optional<T> optional;
     public final Void v;
 
     public OptionalsValue(Optional<T> optional, Void v) {
         this.optional = optional;
         this.v = v;
+    }
+
+    public Optional<T> getOptional() {
+        return this.optional;
     }
 }


### PR DESCRIPTION
It's a common convention to have fields be stored as nullable values,
but the getters for those field returning a non-`null` `Optional` value -
this way forces consumers of the class to explicitly handle the case when the field is `null`.
However, that becomes a problem when used with Jilt's `toBuilder` feature,
since that assumes the getter and the field have the same type.

Special-case this convention in Jilt's `toBuilder` handling,
and add an `.orElse(null)` invocation to the value returned from the getter
if it returns an `Optional`, but the field is not an `Optional`.
Do this for both classic getters (those that start with `get*()` or `is*()`),
and for record-style getters (whose name is equal to the field name) as well.

Fixes #75
